### PR TITLE
Move defining quantitative goals earlier

### DIFF
--- a/product-development/README.md
+++ b/product-development/README.md
@@ -26,6 +26,7 @@ All Tilters are encouraged to collaborate in _definining_ high-level business in
 - Problem statement
 - Solution scope
 - Attached stories with relevant ideas, including designs
+- Link to specific metrics and/or charts that this change targets to improve
 
 Victor is responsible for ensuring that the [backlog of unstarted epics](https://app.clubhouse.io/windmill/epics?state_ids=500008016&state_ids=500008001) is continually full and that epics are increasingly being better defined. There should be no shortage of epics. Dan B and Nick, and Victor are responsible for maintaining the priority of the backlog (higher priority toward the top in the Clubhouse view, when the triangle is pointing down).
 


### PR DESCRIPTION
We already include metrics as part of the formal acceptance criteria for epics; this change asks that we define which metrics we want to improve before starting to work on an epic.