### PR TITLE
process: apply epic template before prioritizing

### DIFF
--- a/product-development/README.md
+++ b/product-development/README.md
@@ -29,9 +29,7 @@ All Tilters are encouraged to collaborate in _definining_ high-level business in
 - Link to specific metrics and/or charts that this change targets to improve
 
 ## Unstarted epics
-By default, Victor is the owner of all unstarted epics. (There are some exceptions, such as unstarted devrel epics that are owned by L.) Victor is responsible for ensuring that the [backlog of unstarted epics](https://app.clubhouse.io/windmill/epics?state_ids=500008016&state_ids=500008001) is continually full and that epics are increasingly being better defined. There should be no shortage of epics. 
-
-Dan B and Nick, and Victor are responsible for maintaining the priority of the backlog (higher priority toward the top in the Clubhouse view, when the triangle is pointing down).
+By default, Victor is the owner of all unstarted epics. (There are some exceptions, such as unstarted devrel epics that are owned by L.) Victor is responsible for ensuring that the [backlog of unstarted epics](https://app.clubhouse.io/windmill/epics?state_ids=500008016&state_ids=500008001) is continually full and that epics are increasingly being better defined. There should be no shortage of epics.
 
 If you have a question or comment about an unstarted epic's scope, design, timeline, priority, or any other aspect, you should direct it at Victor.
 
@@ -39,52 +37,17 @@ Once the epic is `In Progress`, Victor is no longer the owner. [The DRI becomes 
 
 <img src="images/epics-priority.png" height="100" />
 
-## Picking an epic to work on
-When a Tilt engineer is free, they should [pick a high priority unstarted epic](#picking-a-high-priority-unstarted-epic) to work on, or join another engineer (or engineers) already working on an `In Progress` epic. (They might consider [fixing a bug instead](../development/README.md#assign-yourself-a-bug).) Engineers should self-organize and coordinate timelines ad hoc when picking epics. There are no stable teams, no timeboxed sprints, and no synced sprints across teams. Engineers should consider:
-- Working in at least pairs on a given epic, to better facilitate product and code collaboration, avoiding working in siloes.
-- Having a dedicated review Tilter per epic, who may be responsible for code review, content review and/or general deliverable review, who may not necessarily be collaborating during the design and implementation part of the epic, but is responsible for reviewing work.
-- Not working on too many epics concurrently, in order to focus on a smaller number of tasks to reduce context-switching.
+## Prioritizing epics
 
-When you have picked an epic to work on, move it into the `In Progress` state. Remove any existing owner. Make yourself the owner. You are now the [DRI](https://medium.com/@mmamet/directly-responsible-individuals-f5009f465da4) for the epic, and are responsible for driving the epic to completion. An engineer should be the DRI of at most one `In Progress` epic at any time. An epic should only have one owner at any time.
+Dan B and Nick, and Victor are responsible for maintaining the priority of the backlog (higher priority toward the top in the Clubhouse view, when the triangle is pointing down).
 
-Dan and Nick will typically not be DRIs on epics, in order to encourage all Tilters to have more responsibility for innovation and execution of day to day work.
+Before an epic is moved above the line:
+1. Its description should contain the [epic description template](#epic-description-template).
+2. The "Problem statement and references" section should be completed.
 
-## Picking a high priority unstarted epic
-When picking a high priority unstarted epic, look at the epics _above the line_ in the [backlog](https://app.clubhouse.io/windmill/epics?state_ids=500008016&state_ids=500008001) and choose a sensible one based on at least these example scenarios:
-- My skill set is better suited for the third highest priority epic, so I'll pick that one, and save the first two for other folks who can finish them more quickly.
-- The fourth highest priority epic looks to be small so I'll pick that one first and finish it as a quick win before the end of the week.
-- My teammate has expertise in the highest priority epic and I'd like to collaborate and learn from them. But they aren't free just yet. I'll work on the third highest priority epic for now and plan to come back to pair with my teammate next week.
+## Epic description template
 
-Dan B and Nick, and Victor are responsible for setting the location of the line.
-
-Victor is responsible for tracking [open customer requests](https://companies-b164c.firebaseapp.com/customer-requests) as an input for prioritization. 
-
-<img src="images/above-the-line.png" height="150" />
-
-## Reducing scope
-A given epic may have a fairly broad initial business problem. The engineer(s) should carve out and define a smaller problem, and spec out a solution that can be accomplished within a target of **_7 business days_** (counted from when the epic moves into `In Progress`, more below on states). If the solution cannot be finished within 7 business days, keep reducing scope. The epic description should be updated with the smaller scope and acceptance criteria, and the engineer(s) should create additional epics and/or stories to capture the future work. Alternatively, the engineer(s) may create a separate epic with the smaller scope and start work on that one instead (putting the original epic back into the backlog).
-
-The target time period is business calendar time, regardless of how many folks are working on the epic. So if for unplanned circumstances a person in a two person epic needs to be pulled away, the remaining person (who should be the epic owner DRI) may reduce scope to try to meet the target time period due to reduced capacity, saving the unfinished work for a future epic.
-
-The purpose of a single epic is _not_ to completely solve a business problem. Rather, completing an epic should likely achieve incremental progress at addressing a single problem, adding incremental user value as a result. In some cases, any realized user value may only appear in future epics. 
-
-Certain initiatives may require a sustained effort of multiple epics to get to a place where folks are comfortable with the result. Tilters should therefore advocate for epics that close the gap of new but incomplete functionality, or fix tech debt, as per the [advocacy process outlined above](#defining-high-level-business-initiatives-with-clubhouse-epics).
-
-## Epic owner and epic states
-- An epic is in one of three states: `Unstarted`, `In Progress`, `Closed`. 
-- If an epic is in `In Progress` or `Closed`, it must have exactly one owner, who is the DRI.
-
-## DRI responsibilties
-- The DRI is responsible for maintaining the epic state, description, and attached stories updated as the single source of truth of overall work status, at least on a daily basis.
-- The acceptance criteria sections are _especially critical_, including presenting the problem and final implementation in the [weekly epics meeting](#weekly-epics-meeting).
-- The DRI is responsible for reducing scope if additional work is discovered.
-- The DRI is responsible for driving the epic to completion.
-  
-## Example
-For example, suppose usability research suggests that the Tilt Web UI right sidebar is difficult for users to learn. Two engineers develop some ideas to iterate on the existing designs in order to address the problems. But they discover that it's a better idea to first re-architect some of the frontend JavaScript and CSS to accommodate the design changes, repaying some previously incurred tech debt. In this case, the first epic's scope would simply be non-user facing code re-architecture work, that doesn't have immediate user impact, but contributes to solving the usability problem indirectly as an incremental first step. The engineers may work on the second epic right after the first one is done, or it may be given to another team, or simply deferred to a future time. By scoping work to smaller units, Tilt is more flexible in prioritizing whatever is best at (almost) any moment of time as a small organization.
-
-## Finishing an epic with acceptance criteria
-For an epic to be completed (and marked as `Closed` in Clubhouse), the epic description needs to have all the following acceptance criteria marked as completed. Copy and paste the template below into the epic description, and update it accordingly. When a section is done, replace `:white_small_square:` with `:white_check_mark:` to indicate it is done (or explain why the section is not applicable).
+Copy and paste the template below into the epic description, and update it accordingly. When a section is done, replace `:white_small_square:` with `:white_check_mark:` to indicate it is done (or explain why the section is not applicable).
 
 ```
 ---
@@ -130,12 +93,59 @@ Example:
   - Stating that a meeting has been scheduled with a customer to introduce the feature.
 
 ## :white_small_square: Metrics
-- Link to specific metrics and/or charts that this change targets to improve. 
+- Link to specific metrics and/or charts that this change targets to improve.
 - Many changes will not improve metrics in weeks or even months. That's okay. But still need to mention which specific metrics you are targeting.
 - If your change introduces a new metric to measure, collecting that data should be in scope or future work should be captured. For example, if you've created a new feature, you should be tracking it with weekly feature-using accounts, and link to that metric here.
 - Most changes should be small and thus you should be frequently linking to [Company Metrics](https://github.com/tilt-dev/company-private/tree/master/company-metrics) and [Tilt metrics](https://github.com/tilt-dev/company-private/tree/master/tilt-metrics).
 - Refer to [Analytics](https://github.com/tilt-dev/company-private/tree/master/analytics) to determine how to collect metrics. Contact Victor if you're unsure how to use the analytics software or collect the data that you're interested in.
 ```
+
+## Picking an epic to work on
+When a Tilt engineer is free, they should [pick a high priority unstarted epic](#picking-a-high-priority-unstarted-epic) to work on, or join another engineer (or engineers) already working on an `In Progress` epic. (They might consider [fixing a bug instead](../development/README.md#assign-yourself-a-bug).) Engineers should self-organize and coordinate timelines ad hoc when picking epics. There are no stable teams, no timeboxed sprints, and no synced sprints across teams. Engineers should consider:
+- Working in at least pairs on a given epic, to better facilitate product and code collaboration, avoiding working in siloes.
+- Having a dedicated review Tilter per epic, who may be responsible for code review, content review and/or general deliverable review, who may not necessarily be collaborating during the design and implementation part of the epic, but is responsible for reviewing work.
+- Not working on too many epics concurrently, in order to focus on a smaller number of tasks to reduce context-switching.
+
+When you have picked an epic to work on, move it into the `In Progress` state. Remove any existing owner. Make yourself the owner. You are now the [DRI](https://medium.com/@mmamet/directly-responsible-individuals-f5009f465da4) for the epic, and are responsible for driving the epic to completion. An engineer should be the DRI of at most one `In Progress` epic at any time. An epic should only have one owner at any time.
+
+Dan and Nick will typically not be DRIs on epics, in order to encourage all Tilters to have more responsibility for innovation and execution of day to day work.
+
+## Picking a high priority unstarted epic
+When picking a high priority unstarted epic, look at the epics _above the line_ in the [backlog](https://app.clubhouse.io/windmill/epics?state_ids=500008016&state_ids=500008001) and choose a sensible one based on at least these example scenarios:
+- My skill set is better suited for the third highest priority epic, so I'll pick that one, and save the first two for other folks who can finish them more quickly.
+- The fourth highest priority epic looks to be small so I'll pick that one first and finish it as a quick win before the end of the week.
+- My teammate has expertise in the highest priority epic and I'd like to collaborate and learn from them. But they aren't free just yet. I'll work on the third highest priority epic for now and plan to come back to pair with my teammate next week.
+
+Dan B and Nick, and Victor are responsible for setting the location of the line.
+
+Victor is responsible for tracking [open customer requests](https://companies-b164c.firebaseapp.com/customer-requests) as an input for prioritization.
+
+<img src="images/above-the-line.png" height="150" />
+
+## Reducing scope
+A given epic may have a fairly broad initial business problem. The engineer(s) should carve out and define a smaller problem, and spec out a solution that can be accomplished within a target of **_7 business days_** (counted from when the epic moves into `In Progress`, more below on states). If the solution cannot be finished within 7 business days, keep reducing scope. The epic description should be updated with the smaller scope and acceptance criteria, and the engineer(s) should create additional epics and/or stories to capture the future work. Alternatively, the engineer(s) may create a separate epic with the smaller scope and start work on that one instead (putting the original epic back into the backlog).
+
+The target time period is business calendar time, regardless of how many folks are working on the epic. So if for unplanned circumstances a person in a two person epic needs to be pulled away, the remaining person (who should be the epic owner DRI) may reduce scope to try to meet the target time period due to reduced capacity, saving the unfinished work for a future epic.
+
+The purpose of a single epic is _not_ to completely solve a business problem. Rather, completing an epic should likely achieve incremental progress at addressing a single problem, adding incremental user value as a result. In some cases, any realized user value may only appear in future epics.
+
+Certain initiatives may require a sustained effort of multiple epics to get to a place where folks are comfortable with the result. Tilters should therefore advocate for epics that close the gap of new but incomplete functionality, or fix tech debt, as per the [advocacy process outlined above](#defining-high-level-business-initiatives-with-clubhouse-epics).
+
+## Epic owner and epic states
+- An epic is in one of three states: `Unstarted`, `In Progress`, `Closed`.
+- If an epic is in `In Progress` or `Closed`, it must have exactly one owner, who is the DRI.
+
+## DRI responsibilties
+- The DRI is responsible for maintaining the epic state, description, and attached stories updated as the single source of truth of overall work status, at least on a daily basis.
+- The acceptance criteria sections are _especially critical_, including presenting the problem and final implementation in the [weekly epics meeting](#weekly-epics-meeting).
+- The DRI is responsible for reducing scope if additional work is discovered.
+- The DRI is responsible for driving the epic to completion.
+
+## Example
+For example, suppose usability research suggests that the Tilt Web UI right sidebar is difficult for users to learn. Two engineers develop some ideas to iterate on the existing designs in order to address the problems. But they discover that it's a better idea to first re-architect some of the frontend JavaScript and CSS to accommodate the design changes, repaying some previously incurred tech debt. In this case, the first epic's scope would simply be non-user facing code re-architecture work, that doesn't have immediate user impact, but contributes to solving the usability problem indirectly as an incremental first step. The engineers may work on the second epic right after the first one is done, or it may be given to another team, or simply deferred to a future time. By scoping work to smaller units, Tilt is more flexible in prioritizing whatever is best at (almost) any moment of time as a small organization.
+
+## Finishing an epic with acceptance criteria
+For an epic to be completed (and marked as `Closed` in Clubhouse), the epic description needs to have all the acceptance criteria in its description marked as completed.
 
 Here is an example of how an epic description should look when all the acceptance criteria have been completed.
 

--- a/product-development/README.md
+++ b/product-development/README.md
@@ -45,6 +45,10 @@ Before an epic is moved above the line:
 1. Its description should contain the [epic description template](#epic-description-template).
 2. The "Problem statement and references" section should be completed. (Other sections can remain not yet completed.)
 
+This is to help ensure:
+1. An engineer who picks up the epic does not need to duplicate the effort of hunting that information down thesmelves.
+2. Any further information that gets added to the epic description grows within the desired final structure, rather than have to be forced into that structure later.
+
 ## Epic description template
 
 Copy and paste the template below into the epic description, and update it accordingly. When a section is done, replace `:white_small_square:` with `:white_check_mark:` to indicate it is done (or explain why the section is not applicable).

--- a/product-development/README.md
+++ b/product-development/README.md
@@ -43,7 +43,7 @@ Dan B and Nick, and Victor are responsible for maintaining the priority of the b
 
 Before an epic is moved above the line:
 1. Its description should contain the [epic description template](#epic-description-template).
-2. The "Problem statement and references" section should be completed.
+2. The "Problem statement and references" section should be completed. (Other sections can remain not yet completed.)
 
 ## Epic description template
 


### PR DESCRIPTION
### Problems

1. As a dev, I regularly pick up an epic and it's not immediately clear:
  1. what problem it's solving
  2. what customers are interested in it

Presumably during the process of writing the epic and/or deciding to prioritize the epic, someone at the company has considered these questions and could write them down.

The way the process is currently written (and, afaict, practiced), the implementor is responsible for answering these, and often does so at the end of implementing the epic, retracing whatever steps had already been taken.

Additionally, because we introduce the epic template to the epic description relatively late in the process, there is often wasted effort retrofitting that content into the template - if we add the template earlier in the process, we could avoid that.

### Solution

Specify that the template and problem statement should be entered before epics are moved above the line.

This:
1. moves the consideration of the problem statement and customer closer to the design and prioritization process
2. reduces effort retrofitting epic descriptions into the template

### Other possible solutions

- Specify that the template is not required in all cases
- Specify that the template should be used when creating the epic to further mitigate the growth of information outside of the template that later needs to be foisted into the template

### Note

I moved the epic template up in the doc, and the diff unfortunately renders that as moving everything that was above the epic template below the epic template, which makes it look like a lot bigger change than it is. I basically just created a prioritization section and moved the prioritization and epic template stuff there.