### PR TITLE
remove link to basecamp handbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 This is the Tilt company handbook. It documents _how_ we operate at Tilt. It is inspired by other companies' public handbooks:
 
 - [Aula](https://www.notion.so/The-Aula-Brain-4da091a8797840108311d99815b3b36f)
-- [Basecamp](https://basecamp.com/handbook) - [GitHub repo](https://github.com/basecamp/handbook)
 - [GitLab](https://about.gitlab.com/handbook/) - [GitLab repo](https://gitlab.com/gitlab-com/www-gitlab-com/-/tree/master/source/handbook)
 
 The actual work (e.g. product changes) that we plan and execute is tracked in [Clubhouse](https://app.clubhouse.io/windmill).


### PR DESCRIPTION
I'm proposing to remove this reference to Basecamp's handbook in light of what happened there early this year.
[Link to The Verge article: Breaking Camp](https://www.theverge.com/2021/4/27/22406673/basecamp-political-speech-policy-controversy)
TL;DR:
Basecamp banned discussions about political and social topics within the company, after allegations of racism surfaced internally.

My understanding of tilt's culture is the exact opposite of this: We want people to bring their whole selves to work, which includes their political stance and opinions, and call each other out, when we are breaking social rules or our code of conduct.